### PR TITLE
apply transformations on mouse move instead of click and hold

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -94,3 +94,11 @@
  	font-weight: normal;
 	
  }
+ 
+  .metro-tile {
+	border-top-right-radius:2em;
+	-webkit-border-top-right-radius:2em;
+	box-shadow: 2px 2px 2px #888;
+	-moz-box-shadow: 2px 2px 2px #888;
+	-webkit-box-shadow: 2px 2px 2px #888;
+ }

--- a/js/tileJs.js
+++ b/js/tileJs.js
@@ -45,7 +45,7 @@ function Tile( element ){
 		tile.style.webkitFontSmoothing = "antialiased";
 
 		// Listen to mouse events for the tile.
-		tile.addEventListener('mousedown', MouseDown, false);
+		tile.addEventListener('mousemove', MouseDown, false);
 		
 	}
 
@@ -113,7 +113,7 @@ function Tile( element ){
 		tile.style.oTransform = translateString;
 		tile.style.transform = translateString;
 
-		document.addEventListener('mouseup',   MouseUp,   false);    
+		document.addEventListener('mouseout',   MouseUp,   false);    
 
 	};
 	
@@ -144,7 +144,7 @@ function Tile( element ){
 		tile.style.oTransform = idleCss;
 		tile.style.transform = idleCss;
 
-		document.removeEventListener('mouseup',   MouseUp,   false);
+		document.removeEventListener('mouseout',   MouseUp,   false);
 	};
 
 	// Element position finding for non webkit browsers.


### PR DESCRIPTION
Changed mouse up and down events with the mouse move events
Now tiles respond on mouse over instead of click and hold.
Added metro-tile class to styles