### PR TITLE
forces a click event using element.click();

### DIFF
--- a/js/tileJs.js
+++ b/js/tileJs.js
@@ -145,6 +145,8 @@ function Tile( element ){
 		tile.style.transform = idleCss;
 
 		document.removeEventListener('mouseup',   MouseUp,   false);
+		element.click();
+
 	};
 
 	// Element position finding for non webkit browsers.


### PR DESCRIPTION
adding element.click(); to force a click event after the MouseUp. In some browsers (firefox), I was seeing an issue where the combination of mousedown and mouseup event listeners with the transform css3 code were interfering with the click event ever firing. This means that using this code in collaboration with a jQuery fancybox would not work.

This was a simple hack/workaround and I'm not sure if this is the _best_ way have fixing this issue, but it worked for me.
